### PR TITLE
Check response on login

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,3 @@
-
-import os
 import pytest
 import mock
 
@@ -11,7 +9,7 @@ def check_root_keys(response):
 
     expected_keys = ["errorCode", "executionTime", "data", "api_version", "error"]
     for key in expected_keys:
-        if not response.has_key(key):
+        if key not in response:
             return False
 
     return True

--- a/usgs/api.py
+++ b/usgs/api.py
@@ -98,7 +98,7 @@ def dataset_fields(dataset, node, api_key=None):
 def datasets(dataset, node, ll=None, ur=None, start_date=None, end_date=None, api_key=None):
 
     api_key = _get_api_key(api_key)
-    
+
     url = '{}/datasets'.format(USGS_API)
 
     payload = {
@@ -184,6 +184,9 @@ def login(username, password, save=True):
 
     response = r.json()
     api_key = response["data"]
+
+    if api_key is None:
+        raise USGSError(response["error"])
 
     if save:
         with open(TMPFILE, "w") as f:


### PR DESCRIPTION
This addresses #35 

and fixes the tests that were relying on `has_key`.

We are lacking a test for `login`, though. I did not add it because I don't know how to `mock` yet...