### PR TITLE
remove usage of old "mock"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-mock==1.3.0
 pytest==2.8.7
 click>=4.0
 requests>=2.7.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='usgs',
           'requests_futures>=0.9.5'
       ],
       extras_require={
-          'test': ['pytest', 'mock'],
+          'test': ['pytest'],
       },
       entry_points="""
       [console_scripts]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from usgs import api
 from .MockPost import MockPost


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.