### PR TITLE
Replace password-based authentication with token-based authentication

### DIFF
--- a/tests/create_snapshots.py
+++ b/tests/create_snapshots.py
@@ -17,7 +17,7 @@ def create_snapshots():
     Run requests against USGS API for use in tests.
     """
 
-    api_key = api.login(os.environ['USGS_USERNAME'], os.environ['USGS_PASSWORD'])
+    api_key = api.login(os.environ['USGS_USERNAME'], os.environ['USGS_TOKEN'])
 
     # Dataset Fields
     response = api.dataset_fields("LANDSAT_8_C1", "EE", api_key=api_key)

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -54,8 +54,8 @@ class PayloadsTest(unittest.TestCase):
 
     
     def test_login(self):
-        expected = """{"username": "username", "password": "password"}"""
-        payload = payloads.login("username", "password")
+        expected = """{"username": "username", "token": "token"}"""
+        payload = payloads.login("username", "token")
         assert compare_json(payload, expected)
 
 

--- a/usgs/api.py
+++ b/usgs/api.py
@@ -136,19 +136,19 @@ def dataset_search(dataset=None, catalog=None, ll=None, ur=None, start_date=None
 
     return response
 
-def login(username, password, save=True):
+def login(username, token, save=True):
     """
     Log in, creating a temporary API key and optionally storing it for later use.
 
     :param str username: Username of the USGS account to log in with.
-    :param str password: Password of the USGS account to log in with.
+    :param str token: Application Token of the USGS account to log in with.
     :param bool save: If true, the API key will be stored in a local file (~/.usgs)
         until `api.logout` is called to remove it. The stored key will be used by
         other functions to authenticate requests whenever an API key is not explicitly
         provided.
     """
-    url = '{}/login'.format(USGS_API)
-    payload = payloads.login(username, password)
+    url = '{}/login-token'.format(USGS_API)
+    payload = payloads.login(username, token)
 
     with _create_session(api_key=None) as session:
         created = datetime.now().isoformat()

--- a/usgs/payloads.py
+++ b/usgs/payloads.py
@@ -124,18 +124,18 @@ def dataset_search(dataset, catalog, start_date=None, end_date=None, ll=None, ur
 
     return json.dumps(payload)
 
-def login(username, password):
+def login(username, token):
     """
     Upon a successful login, an API key will be returned. This key will be active
     for two hours and should be destroyed upon final use of the service by calling
     the logout method.
 
     :param str username:
-    :param str password:
+    :param str token:
     """
     payload = {
         "username": username,
-        "password": password
+        "token": token
     }
 
     return json.dumps(payload)

--- a/usgs/scripts/cli.py
+++ b/usgs/scripts/cli.py
@@ -84,8 +84,8 @@ def usgs():
 
 @click.command()
 @click.argument("username", envvar='USGS_USERNAME')
-@click.argument("password", envvar='USGS_PASSWORD')
-def cycle_token(username, password):
+@click.argument("token", envvar='USGS_TOKEN')
+def cycle_token(username, token):
 
     credential_filepath = os.path.join(os.path.expanduser("~"), ".usgs")
     with open(credential_filepath) as f:
@@ -97,7 +97,7 @@ def cycle_token(username, password):
     click.echo('The token lifetime is {} seconds'.format(token_lifetime))
     if token_lifetime > approx_two_hours:
         api.logout()
-        api.login(username, password)
+        api.login(username, token)
 
 
 @click.command()
@@ -139,9 +139,9 @@ def download_request(dataset, entity_id, product_id, api_key):
 
 @click.command()
 @click.argument("username", envvar='USGS_USERNAME')
-@click.argument("password", envvar='USGS_PASSWORD')
-def login(username, password):
-    click.echo(api.login(username, password))
+@click.argument("token", envvar='USGS_TOKEN')
+def login(username, token):
+    click.echo(api.login(username, token))
 
 
 @click.command()


### PR DESCRIPTION
To address https://github.com/kapadia/usgs/issues/74 and allow the usgs backend for eodag to work again.

Replaces all `password`-related names with `token`-related ones and updates the API endpoint for logging in. Not backwards compatible.