### PR TITLE
feat: advanced scene_search filtering

### DIFF
--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -66,7 +66,7 @@ class PayloadsTest(unittest.TestCase):
 
 
     def test_scene_search(self):
-        expected = """{"datasetName": "GLS2005", "maxResults": 3, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2006-01-01T00:00:00Z", "end": "2007-12-01T00:00:00Z"}, "spatialFilter": {"filterType": "mbr", "lowerLeft": {"longitude": -135, "latitude": 75}, "upperRight": {"longitude": -120, "latitude": 90}}}}"""
+        expected = """{"datasetName": "GLS2005", "maxResults": 3, "startingNumber": null, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2006-01-01T00:00:00Z", "end": "2007-12-01T00:00:00Z"}, "spatialFilter": {"filterType": "mbr", "lowerLeft": {"longitude": -135, "latitude": 75}, "upperRight": {"longitude": -120, "latitude": 90}}}}"""
 
         ll = {"longitude": -135, "latitude": 75}
         ur = {"longitude": -120, "latitude": 90}
@@ -82,7 +82,7 @@ class PayloadsTest(unittest.TestCase):
 
     def test_scene_search_radial_distance(self):
 
-        expected = """{"datasetName": "GLS2005", "maxResults": 3, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2006-01-01T00:00:00Z", "end": "2007-12-01T00:00:00Z"}, "spatialFilter": {"filterType": "mbr", "lowerLeft": {"longitude": -125.01823502237109, "latitude": 84.99840995696343}, "upperRight": {"longitude": -124.98175340746137, "latitude": 85.00158953883317}}}}"""
+        expected = """{"datasetName": "GLS2005", "maxResults": 3, "startingNumber": null, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2006-01-01T00:00:00Z", "end": "2007-12-01T00:00:00Z"}, "spatialFilter": {"filterType": "mbr", "lowerLeft": {"longitude": -125.01823502237109, "latitude": 84.99840995696343}, "upperRight": {"longitude": -124.98175340746137, "latitude": 85.00158953883317}}}}"""
 
         lat = 85
         lng = -125

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -94,3 +94,32 @@ class PayloadsTest(unittest.TestCase):
             "GLS2005", lat=lat, lng=lng, distance=dist, start_date=start_date, end_date=end_date, max_results=3)
 
         assert compare_json(payload, expected), "wrong result: {r} \n for expected: {e}".format(r=payload, e=expected)
+
+
+    def test_scene_search_with_scene_filter(self):
+        expected = """{"datasetName": "GLS2005", "maxResults": 3, "startingNumber": null, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2006-01-01T00:00:00Z", "end": "2007-12-01T00:00:00Z"}, "ingestFilter": {"start": "2010-01-01", "end": "2012-01-31"}}}"""
+
+        start_date = "2006-01-01T00:00:00Z"
+        end_date = "2007-12-01T00:00:00Z"
+        scene_filter = {"ingestFilter": {"start": "2010-01-01", "end": "2012-01-31"}}
+
+        payload = payloads.scene_search(
+            "GLS2005", start_date=start_date, end_date=end_date,
+            max_results=3, scene_filter=scene_filter)
+
+        assert compare_json(payload, expected), "wrong result: {r} \n for expected: {e}".format(r=payload, e=expected)
+
+
+    def test_scene_search_scene_filter_overrides(self):
+        # scene_filter should override values set by other parameters
+        expected = """{"datasetName": "GLS2005", "maxResults": 3, "startingNumber": null, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2010-01-01", "end": "2010-12-31"}}}"""
+
+        start_date = "2006-01-01T00:00:00Z"
+        end_date = "2007-12-01T00:00:00Z"
+        scene_filter = {"acquisitionFilter": {"start": "2010-01-01", "end": "2010-12-31"}}
+
+        payload = payloads.scene_search(
+            "GLS2005", start_date=start_date, end_date=end_date,
+            max_results=3, scene_filter=scene_filter)
+
+        assert compare_json(payload, expected), "wrong result: {r} \n for expected: {e}".format(r=payload, e=expected)

--- a/usgs/api.py
+++ b/usgs/api.py
@@ -222,38 +222,41 @@ def scene_search(dataset,
         start_date=None, end_date=None,
         ll=None, ur=None,
         lat=None, lng=None, distance=100,
-        where=None, starting_number=1, sort_order="DESC", api_key=None):
+        where=None, scene_filter=None, starting_number=1, sort_order="DESC", api_key=None):
     """
-    :param dataset:
+    :param str dataset:
         USGS dataset (e.g. EO1_HYP_PUB, LANDSAT_8)
-    :param lat:
+    :param str lat:
         Latitude
-    :param lng:
+    :param str lng:
         Longitude
-    :param distance:
+    :param int distance:
         Distance in meters used to for a radial search
-    :param ll:
+    :param dict ll:
         Dictionary of longitude/latitude coordinates for the lower left corner
         of a bounding box search. e.g. { "longitude": 0.0, "latitude": 0.0 }
-    :param ur:
+    :param dict ur:
         Dictionary of longitude/latitude coordinates for the upper right corner
         of a bounding box search. e.g. { "longitude": 0.0, "latitude": 0.0 }
-    :param start_date:
+    :param str start_date:
         Start date for when a scene has been acquired
-    :param end_date:
+    :param str end_date:
         End date for when a scene has been acquired
-    :where:
+    :param dict where:
         Dictionary representing key/values for finer grained conditional
         queries. Only a subset of metadata fields are supported. Available
         fields depend on the value of `dataset`, and maybe be found by
         submitting a dataset_filters query.
-    :max_results:
+    :param int max_results:
         Maximum results returned by the server
-    :starting_number:
+    :param dict scene_filter:
+        Additional filters to apply to the "sceneFilter". Can override filters set using other parameters.
+        e.g. {"ingestFilter": {"start": "2010-01-01", "end": "2012-01-31"}}
+    :param int starting_number:
         Starting offset for results of a query.
-    :sort_order:
+    :param str sort_order:
         Order in which results are sorted. Ascending or descending w.r.t the acquisition date.
-    :api_key:
+    :param str api_key:
         API key for EROS. Required for searching.
     """
     api_key = _get_api_key(api_key)
@@ -264,7 +267,7 @@ def scene_search(dataset,
             dataset, max_results=max_results, metadata_type=metadata_type,
             start_date=start_date, end_date=end_date,
             ll=ll, ur=ur, lat=lat, lng=lng, distance=distance, where=where,
-            starting_number=starting_number)
+            scene_filter=scene_filter, starting_number=starting_number)
         r = session.post(url, payload)
 
     response = r.json()

--- a/usgs/payloads.py
+++ b/usgs/payloads.py
@@ -184,7 +184,7 @@ def scene_search(
     dataset, max_results=None, metadata_type=None, start_date=None,
     end_date=None, ll=None, ur=None,
     lat=None, lng=None, distance=100,
-    where=None, starting_number=None):
+    where=None, starting_number=None, scene_filter=None):
 
     payload = defaultdict(dict, {
         "datasetName": dataset,
@@ -220,5 +220,8 @@ def scene_search(
             "value": where["value"],
             "operand": "="
         }
+
+    if scene_filter is not None:
+        payload["sceneFilter"].update(scene_filter)
 
     return json.dumps(payload)


### PR DESCRIPTION
Adds a new `scene_filter` to `api.scene_search` to allow advanced filtering.

Usage example:

```py
api.scene_search(
    "GLS2005",
    start_date="2006-01-01T00:00:00Z",
    end_date="2007-12-01T00:00:00Z",
    max_results=3,
    scene_filter={"ingestFilter": {"start": "2010-01-01", "end": "2010-01-31"}}
)
```
Requires #78 for tests