### PR TITLE
feat: requests error handling

### DIFF
--- a/tests/MockPost.py
+++ b/tests/MockPost.py
@@ -2,18 +2,29 @@
 import os
 import json
 
+import requests
+
 testdir = os.path.dirname(os.path.abspath(__file__))
 
 
 class MockPost(object):
 
 
-    def __init__(self, filename):
+    def __init__(self, filename=None, status_code=200, reason="OK"):
         self.filename = filename
+        self.status_code = status_code
+        self.reason = reason
 
 
-    def __call__(self, url, payload):
+    def __call__(self, url, payload=None):
         return self
+
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(
+                "%d %s" % (self.status_code, self.reason))
+        return None
 
 
     def json(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,9 @@
-import pytest
+import unittest
 from unittest import mock
 
-from usgs import api
+import requests
+
+from usgs import api, USGSError
 from .MockPost import MockPost
 
 
@@ -111,3 +113,74 @@ def test_scene_search():
 
     for expected_key in expected_keys:
         assert expected_key in response['data']["results"][0]
+
+
+class HttpErrorTests(unittest.TestCase):
+
+    @mock.patch('usgs.api.requests.Session.post', MockPost(status_code=500, reason="Server Error"))
+    def test_dataset_filters_http_error(self):
+        with self.assertRaises(USGSError) as cm:
+            api.dataset_filters("LANDSAT_8_C1")
+        assert "HTTP error occurred during dataset filters request" in str(cm.exception)
+        assert isinstance(cm.exception.__cause__, requests.HTTPError)
+
+    @mock.patch('usgs.api.requests.Session.post', MockPost(status_code=500, reason="Server Error"))
+    def test_download_options_http_error(self):
+        with self.assertRaises(USGSError) as cm:
+            api.download_options("LANDSAT_8_C1", ["LC82260782020217LGN00"])
+        assert "HTTP error occurred during download options request" in str(cm.exception)
+        assert isinstance(cm.exception.__cause__, requests.HTTPError)
+
+    @mock.patch('usgs.api.requests.Session.post', MockPost(status_code=500, reason="Server Error"))
+    def test_dataset_download_options_http_error(self):
+        with self.assertRaises(USGSError) as cm:
+            api.dataset_download_options("LANDSAT_8_C1")
+        assert "HTTP error occurred during dataset download options request" in str(cm.exception)
+        assert isinstance(cm.exception.__cause__, requests.HTTPError)
+
+    @mock.patch('usgs.api.requests.Session.post', MockPost(status_code=500, reason="Server Error"))
+    def test_download_request_http_error(self):
+        with self.assertRaises(USGSError) as cm:
+            api.download_request(
+                "LANDSAT_8_C1", "LC82260782020217LGN00", "5e83d0b84df8d8c2")
+        assert "HTTP error occurred during download request" in str(cm.exception)
+        assert isinstance(cm.exception.__cause__, requests.HTTPError)
+
+    @mock.patch('usgs.api.requests.Session.post', MockPost(status_code=500, reason="Server Error"))
+    def test_dataset_search_http_error(self):
+        with self.assertRaises(USGSError) as cm:
+            api.dataset_search()
+        assert "HTTP error occurred during dataset search request" in str(cm.exception)
+        assert isinstance(cm.exception.__cause__, requests.HTTPError)
+
+    @mock.patch('usgs.api.requests.Session.post', MockPost(status_code=500, reason="Server Error"))
+    def test_login_http_error(self):
+        with self.assertRaises(USGSError) as cm:
+            api.login("user", "token", save=False)
+        assert "HTTP error occurred during login request" in str(cm.exception)
+        assert isinstance(cm.exception.__cause__, requests.HTTPError)
+
+    @mock.patch('usgs.api.requests.Session.post', MockPost(status_code=500, reason="Server Error"))
+    def test_scene_metadata_http_error(self):
+        with self.assertRaises(USGSError) as cm:
+            api.scene_metadata("LANDSAT_8_C1", "LC82260782020217LGN00")
+        assert "HTTP error occurred during scene metadata request" in str(cm.exception)
+        assert isinstance(cm.exception.__cause__, requests.HTTPError)
+
+    @mock.patch('usgs.api.requests.Session.post', MockPost(status_code=500, reason="Server Error"))
+    def test_scene_search_http_error(self):
+        with self.assertRaises(USGSError) as cm:
+            api.scene_search("LANDSAT_8_C1")
+        assert "HTTP error occurred during scene search request" in str(cm.exception)
+        assert isinstance(cm.exception.__cause__, requests.HTTPError)
+
+    @mock.patch('usgs.api.requests.Session.post', MockPost(status_code=500, reason="Server Error"))
+    @mock.patch('usgs.api.os.remove')
+    @mock.patch('usgs.api.os.path.exists', return_value=True)
+    def test_logout_http_error(self, mock_exists, mock_remove):
+        with self.assertRaises(USGSError) as cm:
+            api.logout()
+        assert "HTTP error occurred during logout request" in str(cm.exception)
+        assert isinstance(cm.exception.__cause__, requests.HTTPError)
+        # credentials file is always removed on logout, even when the request fails
+        mock_remove.assert_called_once()

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -66,7 +66,7 @@ class PayloadsTest(unittest.TestCase):
 
 
     def test_scene_search(self):
-        expected = """{"datasetName": "GLS2005", "maxResults": 3, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2006-01-01T00:00:00Z", "end": "2007-12-01T00:00:00Z"}, "spatialFilter": {"filterType": "mbr", "lowerLeft": {"longitude": -135, "latitude": 75}, "upperRight": {"longitude": -120, "latitude": 90}}}}"""
+        expected = """{"datasetName": "GLS2005", "maxResults": 3, "startingNumber": null, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2006-01-01T00:00:00Z", "end": "2007-12-01T00:00:00Z"}, "spatialFilter": {"filterType": "mbr", "lowerLeft": {"longitude": -135, "latitude": 75}, "upperRight": {"longitude": -120, "latitude": 90}}}}"""
 
         ll = {"longitude": -135, "latitude": 75}
         ur = {"longitude": -120, "latitude": 90}
@@ -82,7 +82,7 @@ class PayloadsTest(unittest.TestCase):
 
     def test_scene_search_radial_distance(self):
 
-        expected = """{"datasetName": "GLS2005", "maxResults": 3, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2006-01-01T00:00:00Z", "end": "2007-12-01T00:00:00Z"}, "spatialFilter": {"filterType": "mbr", "lowerLeft": {"longitude": -125.01823502237109, "latitude": 84.99840995696343}, "upperRight": {"longitude": -124.98175340746137, "latitude": 85.00158953883317}}}}"""
+        expected = """{"datasetName": "GLS2005", "maxResults": 3, "startingNumber": null, "metadataType": null, "sceneFilter": {"acquisitionFilter": {"start": "2006-01-01T00:00:00Z", "end": "2007-12-01T00:00:00Z"}, "spatialFilter": {"filterType": "mbr", "lowerLeft": {"longitude": -125.01823502237109, "latitude": 84.99840995696343}, "upperRight": {"longitude": -124.98175340746137, "latitude": 85.00158953883317}}}}"""
 
         lat = 85
         lng = -125

--- a/usgs/api.py
+++ b/usgs/api.py
@@ -24,6 +24,13 @@ def _get_api_key(api_key):
 
     return api_key
 
+def _check_for_requests_error(response, message_context=""):
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        msg = f"HTTP error occurred during {message_context} request, {e}"
+        raise USGSError(msg) from e
+
 def _check_for_usgs_error(data):
 
     error_code = data['errorCode']
@@ -61,6 +68,8 @@ def dataset_filters(dataset, api_key=None):
         payload = payloads.dataset_filters(dataset)
         r = session.post(url, payload)
 
+    _check_for_requests_error(r, "dataset filters")
+
     response = r.json()
 
     _check_for_usgs_error(response)
@@ -74,6 +83,8 @@ def download_options(dataset, entity_ids, api_key=None):
         url = '{}/download-options'.format(USGS_API)
         payload = payloads.download_options(dataset, entity_ids)
         r = session.post(url, payload)
+
+    _check_for_requests_error(r, "download options")
 
     response = r.json()
 
@@ -96,6 +107,8 @@ def dataset_download_options(dataset, api_key=None):
         payload = payloads.dataset_download_options(dataset)
         r = session.post(url, payload)
 
+    _check_for_requests_error(r, "dataset download options")
+
     response = r.json()
 
     _check_for_usgs_error(response)
@@ -114,6 +127,8 @@ def download_request(dataset, entity_id, product_id, api_key=None):
         payload = payloads.download_request(dataset, entity_id, product_id)
         r = session.post(url, payload)
 
+    _check_for_requests_error(r, "download request")
+
     response = r.json()
 
     _check_for_usgs_error(response)
@@ -129,6 +144,8 @@ def dataset_search(dataset=None, catalog=None, ll=None, ur=None, start_date=None
             dataset=dataset, catalog=catalog, start_date=start_date,
             end_date=end_date, ll=ll, ur=ur)
         r = session.post(url, payload)
+
+    _check_for_requests_error(r, "dataset search")
 
     response = r.json()
 
@@ -153,6 +170,8 @@ def login(username, token, save=True):
     with _create_session(api_key=None) as session:
         created = datetime.now().isoformat()
         r = session.post(url, payload)
+
+    _check_for_requests_error(r, "login")
 
     response = r.json()
 
@@ -181,19 +200,21 @@ def logout():
 
     url = '{}/logout'.format(USGS_API)
 
-    with _create_session(api_key=None) as session:
-        r = session.post(url)
-
-    response = r.json()
-
     try:
-        _check_for_usgs_error(response)
-    except USGSAuthExpiredError:
-        pass
+        with _create_session(api_key=None) as session:
+            r = session.post(url)
 
-    os.remove(TMPFILE)
+        _check_for_requests_error(r, "logout")
 
-    return response
+        response = r.json()
+        try:
+            _check_for_usgs_error(response)
+        except USGSAuthExpiredError:
+            pass
+
+        return response
+    finally:
+        os.remove(TMPFILE)
 
 def scene_metadata(dataset, entity_id, api_key=None):
     """
@@ -210,6 +231,8 @@ def scene_metadata(dataset, entity_id, api_key=None):
 
     with _create_session(api_key) as session:
         r = session.post(url, payload)
+
+    _check_for_requests_error(r, "scene metadata")
 
     response = r.json()
 
@@ -266,6 +289,8 @@ def scene_search(dataset,
             ll=ll, ur=ur, lat=lat, lng=lng, distance=distance, where=where,
             starting_number=starting_number)
         r = session.post(url, payload)
+
+    _check_for_requests_error(r, "scene search")
 
     response = r.json()
 


### PR DESCRIPTION
Adds requests responses status check and handling.

Prevents `JSONDecodeError` from being raised when calling `response.json()` without having checked response status.

Requires https://github.com/kapadia/usgs/pull/78 for tests.